### PR TITLE
Add third arm animation frame

### DIFF
--- a/assets/script.js
+++ b/assets/script.js
@@ -36,16 +36,19 @@ BombImg.onload = ()=> bombReady = true;
 BombImg.src = 'assets/bombe.png';
 
 
-// --- PNG de la main (2 frames) ---
+// --- PNG de la main (3 frames) ---
 const Hand = {
   open: new Image(),
+  close: new Image(),
   pinch: new Image(),
   ready: false
 };
 Hand.open.src  = 'assets/main_open.png';
+Hand.close.src = 'assets/main_close.png';
 Hand.pinch.src = 'assets/main_pince.png';
 Promise.all([
   new Promise(r => Hand.open.onload = r),
+  new Promise(r => Hand.close.onload = r),
   new Promise(r => Hand.pinch.onload = r),
 ]).then(()=> Hand.ready = true);
   const VERSION = '1.0.0';
@@ -369,7 +372,7 @@ this.x = clamp(this.x, -overflow, BASE_W - this.w + overflow);
   constructor(game){
     this.g = game;
     this.t = 0;             // timer d'anim (pincée)
-    this.frame = 0;         // 0..1 (open/pinch)
+    this.frame = 0;         // 0..2 (open/close/pinch)
     this.handX = BASE_W/2;  // position horizontale de la main
     this.spriteHCapPx = 0;
 
@@ -392,9 +395,9 @@ this.x = clamp(this.x, -overflow, BASE_W - this.w + overflow);
   }
 
   update(dt){
-    // Animation 2 frames
+    // Animation 3 frames
     this.t += dt;
-    if (this.t > 0.2){ this.t = 0; this.frame = (this.frame + 1) % 2; }
+    if (this.t > 0.2){ this.t = 0; this.frame = (this.frame + 1) % 3; }
 
     // Re-ciblage horizontal
     this.retarget -= dt;
@@ -428,7 +431,8 @@ this.x = clamp(this.x, -overflow, BASE_W - this.w + overflow);
     const y = 6;                              // léger padding haut
 
     // Sélection de frame
-    const img = (this.frame === 0 ? Hand.open : Hand.pinch);
+    const frames = [Hand.open, Hand.close, Hand.pinch];
+    const img = frames[this.frame] || Hand.open;
 
     // Si les images ne sont pas encore prêtes, on ne dessine rien (ou un placeholder)
     if (!Hand.ready || !img || !(img.naturalWidth > 0)) {


### PR DESCRIPTION
## Summary
- load the new `main_close.png` arm frame and include it in the hand asset set
- cycle the arm animation across the three frames and pick the matching image when drawing

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68cdb5a80c508323aeaea5475dd7d527