### PR TITLE
Restore legacy burst effect in FxManager

### DIFF
--- a/www/js/main.js
+++ b/www/js/main.js
@@ -239,6 +239,14 @@ class FxManager {
     return effect;
   }
 
+  // --- Méthode rétro-compatible ---
+  burst(x, y, color = "gold", radius = 20) {
+    const fx = new FxPositiveImpact(x, y);
+    if (color) CONFIG.fx.positive.color = color;
+    if (radius) CONFIG.fx.positive.radius = radius;
+    this.add(fx);
+  }
+
   update(dt) {
     for (const fx of this.effects) {
       if (fx.dead) continue;


### PR DESCRIPTION
## Summary
- add a retro-compatible `burst` helper to `FxManager` that reuses `FxPositiveImpact`
- ensure legacy burst calls still render a short-lived positive impact effect

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e28c11711c83239638139701f5c318